### PR TITLE
Add npm publish workflows

### DIFF
--- a/.github/workflows/npm-publish-beta.yml
+++ b/.github/workflows/npm-publish-beta.yml
@@ -1,0 +1,53 @@
+name: NPM Publish Beta
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  publish-beta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build
+        run: npm run build
+
+      - name: Generate beta version
+        id: beta-version
+        run: |
+          # Get the current version from package.json
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          
+          # For PR: use PR number in version
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BETA_VERSION="$CURRENT_VERSION-beta.pr.${{ github.event.pull_request.number }}"
+          else
+            # For develop: use commit hash
+            SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+            BETA_VERSION="$CURRENT_VERSION-beta.$SHORT_SHA"
+          fi
+          
+          # Set output for use in next step
+          echo "version=$BETA_VERSION" >> $GITHUB_OUTPUT
+          
+          # Update package.json with new version
+          npm version $BETA_VERSION --no-git-tag-version
+        
+      - name: Publish beta to npm
+        run: npm publish --tag beta --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,29 @@
+name: NPM Publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build
+        run: npm run build
+        
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR adds GitHub Actions workflows for npm package publishing.

Changes:
- Add npm-publish.yml for releasing stable versions
- Add npm-publish-beta.yml for publishing beta versions from develop branch and PRs
- Configure workflows to use NPM_TOKEN for authentication

Note: Requires NPM_TOKEN secret to be configured in repository settings.