### PR TITLE
Release v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,13 @@ npm i @space48/sdm
 Pre-requisites for installation
 -------------------------------
 
-### Configure @space48 npm scope
+### Install sdm
 
-sdm is distributed as a private npm package in the @space48 scope. To install sdm and other private Space 48 npm
-packages, you must first configure the @space48 scope in npm.
+Install sdm from npm:
 
-1. [Create a github access token](https://github.com/settings/tokens/new) with `read packages` and `repo` privileges
-2. Configure npm so that you can install sdm and other private Space 48 packages using your email and token created in Step 1 as yur username & password
-
-    ```bash
-    npm login --registry=https://npm.pkg.github.com --scope=@space48
-    ```
+```bash
+npm install @space48/sdm
+```
 
 ### Enable node 20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@space48/sdm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Command line tools for piping data in and out of APIs",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Update @space48 packages to use npm registry instead of GitHub Packages

This release fixes the package source configuration to pull @space48/json-pipe from the public npm registry instead of GitHub Packages.

Changes:
- Configured @space48 npm scope to use registry.npmjs.org
- Updated README documentation to remove GitHub Packages authentication
- Version bump to 1.0.1

Once merged, this will automatically publish to npm via GitHub Actions.